### PR TITLE
Fix: QUnit files

### DIFF
--- a/ui-components/tests/test.html
+++ b/ui-components/tests/test.html
@@ -4,12 +4,12 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width">
     <title>QUnit Example</title>
-    <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.9.2.css">
+    <link rel="stylesheet" href="../node_modules/qunit/qunit/qunit.css">
 </head>
 <body>
 <div id="qunit"></div>
 <div id="qunit-fixture"></div>
-<script src="https://code.jquery.com/qunit/qunit-2.9.2.js"></script>
+<script src="../node_modules/qunit/qunit/qunit.js"></script>
 <script type="module" src="test-index.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This PR uses QUnit files (such as `qunit.css` and `qunit.js`) stored locally in the node_modules folder, so that there is no `https://code.jquery.com/qunit/` reference anymore.