### PR TITLE
Fix: Loading items

### DIFF
--- a/ui-components/app/components/file-list-page/index.js
+++ b/ui-components/app/components/file-list-page/index.js
@@ -207,7 +207,7 @@ export default class FileListPage extends StateAwareComponent {
     });
 
     this.onStateChanged('isRenameItemLoading', ({detail: {state}}) => {
-      this.fileList.isSelectedItemLoading = state.isRenameItemLoading;
+      this.fileList.isRenameItemInProgress = state.isRenameItemLoading;
     });
 
     this.onStateChanged('renameItemLoadingError', ({detail: {state}}) => {

--- a/ui-components/app/components/file-list/index.js
+++ b/ui-components/app/components/file-list/index.js
@@ -88,7 +88,7 @@ export default class FileList extends Component {
    */
   set loadingItems(itemIds) {
     this._fileItems.forEach((item) => {
-      item.isLoading = itemIds.includes(item.id);
+      item.isLoadingActions = itemIds.includes(item.id);
     });
 
     this._loadingItems = itemIds;
@@ -112,7 +112,7 @@ export default class FileList extends Component {
    *
    * @param {boolean} isLoading - The flag that shows if the selected item is loading or not.
    */
-  set isSelectedItemLoading(isLoading) {
+  set isRenameItemInProgress(isLoading) {
     if (isLoading) {
       this._loadingItem = this._selectedItem;
     }

--- a/ui-components/app/components/list-item/index.js
+++ b/ui-components/app/components/list-item/index.js
@@ -38,6 +38,7 @@ export default class ListItem extends Component {
             <td class="cell-actions" data-test="cell-actions">
                 <div class="action-buttons" data-test="action-buttons">
                     <span class="glyphicon glyphicon-remove-circle" data-test="remove-item-button"></span>
+                    <div class="loader-small" data-test="actions-loader"></div>
                 </div>
             </td>
         </tr>

--- a/ui-components/app/components/list-item/index.js
+++ b/ui-components/app/components/list-item/index.js
@@ -206,6 +206,19 @@ export default class ListItem extends Component {
   }
 
   /**
+   * Sets if the current item has action buttons loading or not.
+   *
+   * @param {boolean} value - The flag that shows whether the item's actions are loading.
+   */
+  set isLoadingActions(value) {
+    if (value) {
+      this.rootElement.classList.add('actions-loading');
+    } else {
+      this.rootElement.classList.remove('actions-loading');
+    }
+  }
+
+  /**
    * Sets the function to be called when the item name changes.
    *
    * @param {Function} handler - The function to call when the item name changes.

--- a/ui-components/app/components/list-item/index.js
+++ b/ui-components/app/components/list-item/index.js
@@ -198,11 +198,7 @@ export default class ListItem extends Component {
    * @param {boolean} value - The flag that shows whether the current list item is loading or not.
    */
   set isLoading(value) {
-    if (value) {
-      this.rootElement.classList.add('loading');
-    } else {
-      this.rootElement.classList.remove('loading');
-    }
+    this.rootElement.classList.toggle('loading', value);
   }
 
   /**
@@ -211,11 +207,7 @@ export default class ListItem extends Component {
    * @param {boolean} value - The flag that shows whether the item's actions are loading.
    */
   set isLoadingActions(value) {
-    if (value) {
-      this.rootElement.classList.add('actions-loading');
-    } else {
-      this.rootElement.classList.remove('actions-loading');
-    }
+    this.rootElement.classList.toggle('actions-loading', value);
   }
 
   /**

--- a/ui-components/app/css/styles.css
+++ b/ui-components/app/css/styles.css
@@ -239,12 +239,21 @@ a:hover {
     display: inline-block;
 }
 
-/*.files tr.loading td.cell-actions .action-buttons {*/
-/*    visibility: hidden;*/
-/*}*/
-
 .files .actions-loading .cell-actions .glyphicon {
     color: #808080;
+}
+
+.files .actions-loading .cell-actions .loader-small {
+    visibility: visible;
+}
+
+.files .cell-actions .loader-small {
+    visibility: hidden;
+    position: absolute;
+    left: 50%;
+    margin-left: -6px;
+    top: 50%;
+    margin-top: -6px;
 }
 
 .files td {
@@ -271,6 +280,7 @@ a:hover {
 
 .files td.cell-actions {
     width: 100px;
+    position: relative;
 }
 
 .files td.cell-actions .glyphicon {


### PR DESCRIPTION
This PR adds two different "in progress" states for files an folders:
* **Renaming in progress.** It hides the item name and shows the loader instead.
* **Action in progress.** Disables action buttons and shows a loader.