### PR TITLE
Fix: Action icons while loading

### DIFF
--- a/ui-components/app/css/styles.css
+++ b/ui-components/app/css/styles.css
@@ -239,8 +239,8 @@ a:hover {
     display: inline-block;
 }
 
-.files .actions-loading .cell-actions .glyphicon {
-    color: #808080;
+.files .actions-loading .cell-actions .glyphicon, .files .loading .cell-actions .glyphicon {
+    visibility: hidden;
 }
 
 .files .actions-loading .cell-actions .loader-small {


### PR DESCRIPTION
This PR hides the action buttons while a file/folder item is in any of the loading states.