### PR TITLE
Fix: Button loaders

### DIFF
--- a/ui-components/app/css/styles.css
+++ b/ui-components/app/css/styles.css
@@ -28,6 +28,11 @@ a:hover {
     border-color: #1b3e5e;
 }
 
+.button .loader-small {
+    margin-top: 4px;
+    margin-bottom: -3px;
+}
+
 .application-box {
     box-sizing: border-box;
     background-color: #fff;


### PR DESCRIPTION
This PR places the button loader to the center of a button.
Before:
![image](https://user-images.githubusercontent.com/59995407/83600690-c3081700-a577-11ea-829e-6259fb6cbe0f.png)

Now:
![image](https://user-images.githubusercontent.com/59995407/83600643-acfa5680-a577-11ea-8a8c-a46bd134b6d9.png)
